### PR TITLE
Fix fps drops from image processing work on main thread

### DIFF
--- a/Sources/SwiftUIGIF/SwiftUIGIF.swift
+++ b/Sources/SwiftUIGIF/SwiftUIGIF.swift
@@ -63,11 +63,15 @@ public class UIGIFImage: UIView {
     }
     
     func updateGIF(data: Data) {
-        imageView.image = UIImage.gifImage(data: data)
+        Task {
+            imageView.image = await UIImage.gifImage(data: data)
+        }
     }
     
     func updateGIF(name: String) {
-        imageView.image = UIImage.gifImage(name: name)
+        Task {
+            imageView.image = await UIImage.gifImage(name: name)
+        }
     }
     
     private func initView() {
@@ -76,7 +80,7 @@ public class UIGIFImage: UIView {
 }
 
 public extension UIImage {
-    class func gifImage(data: Data) -> UIImage? {
+    class func gifImage(data: Data) async -> UIImage? {
         guard let source = CGImageSourceCreateWithData(data as CFData, nil)
         else {
             return nil
@@ -107,13 +111,13 @@ public extension UIImage {
                                      duration: Double(duration) / 1000.0)
     }
     
-    class func gifImage(name: String) -> UIImage? {
+    class func gifImage(name: String) async -> UIImage? {
         guard let url = Bundle.main.url(forResource: name, withExtension: "gif"),
               let data = try? Data(contentsOf: url)
         else {
             return nil
         }
-        return gifImage(data: data)
+        return await gifImage(data: data)
     }
 }
 

--- a/Sources/SwiftUIGIF/SwiftUIGIF.swift
+++ b/Sources/SwiftUIGIF/SwiftUIGIF.swift
@@ -63,14 +63,24 @@ public class UIGIFImage: UIView {
     }
     
     func updateGIF(data: Data) {
-        Task {
-            imageView.image = await UIImage.gifImage(data: data)
+        updateWithImage {
+            UIImage.gifImage(data: data)
         }
     }
     
     func updateGIF(name: String) {
-        Task {
-            imageView.image = await UIImage.gifImage(name: name)
+        updateWithImage {
+            UIImage.gifImage(name: name)
+        }
+    }
+    
+    private func updateWithImage(_ getImage: @escaping () -> UIImage?) {
+        DispatchQueue.global(qos: .userInteractive).async {
+            let image = getImage()
+            
+            DispatchQueue.main.async {
+                self.imageView.image = image
+            }
         }
     }
     
@@ -80,7 +90,7 @@ public class UIGIFImage: UIView {
 }
 
 public extension UIImage {
-    class func gifImage(data: Data) async -> UIImage? {
+    class func gifImage(data: Data) -> UIImage? {
         guard let source = CGImageSourceCreateWithData(data as CFData, nil)
         else {
             return nil
@@ -111,13 +121,13 @@ public extension UIImage {
                                      duration: Double(duration) / 1000.0)
     }
     
-    class func gifImage(name: String) async -> UIImage? {
+    class func gifImage(name: String) -> UIImage? {
         guard let url = Bundle.main.url(forResource: name, withExtension: "gif"),
               let data = try? Data(contentsOf: url)
         else {
             return nil
         }
-        return await gifImage(data: data)
+        return gifImage(data: data)
     }
 }
 


### PR DESCRIPTION
Hi, thank you for the library!

I recently used it to display multiple GIF's in grid. I had some performance issue due to main thread load. I used async feature to prevent fps drops, by moving image processing work from main thread to background thread